### PR TITLE
Additional configuration options

### DIFF
--- a/examples/syslog-unix.rs
+++ b/examples/syslog-unix.rs
@@ -3,9 +3,10 @@ extern crate slog;
 extern crate slog_syslog;
 
 use slog_syslog::{Facility, SyslogBuilder};
+use slog::Level;
 
 fn main() {
-    let syslog = SyslogBuilder::new().facility(Facility::User).build();
+    let syslog = SyslogBuilder::new().facility(Facility::User).log_priority(Level::Error).build();
     let root = slog::Logger::root(syslog, o!());
 
     info!(root, "Starting");

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,9 +1,10 @@
-use Facility;
+use ::{Facility, get_priority};
 use format::{DefaultMsgFormat, MsgFormat};
 use libc;
 use SyslogDrain;
 use std::borrow::Cow;
 use std::ffi::{CStr, CString};
+use slog::Level;
 
 /// Builds a [`SyslogDrain`].
 /// 
@@ -19,6 +20,7 @@ pub struct SyslogBuilder<F: MsgFormat = DefaultMsgFormat> {
     pub(crate) facility: Facility,
     pub(crate) ident: Option<Cow<'static, CStr>>,
     pub(crate) option: libc::c_int,
+    pub(crate) log_priority: libc::c_int,
     pub(crate) format: F,
 }
 
@@ -28,6 +30,7 @@ impl Default for SyslogBuilder {
             facility: Facility::default(),
             ident: None,
             option: 0,
+            log_priority: 0,
             format: DefaultMsgFormat,
         }
     }
@@ -237,6 +240,14 @@ impl<F: MsgFormat> SyslogBuilder<F> {
         self
     }
 
+    /// Log all messages with the given syslog priority
+    #[inline]
+    pub fn log_priority(mut self, log_priority: Level) -> Self {
+        self.log_priority = get_priority(log_priority);
+        self
+    }
+
+
     /// Set a format for log messages and structured data.
     /// 
     /// The default is [`DefaultMsgFormat`].
@@ -258,6 +269,7 @@ impl<F: MsgFormat> SyslogBuilder<F> {
             facility: self.facility,
             ident: self.ident,
             option: self.option,
+            log_priority: self.log_priority,
             format,
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,7 +6,7 @@
 
 use Facility;
 use format::{BasicMsgFormat, DefaultMsgFormat, MsgFormat};
-use slog::{self, OwnedKVList, Record};
+use slog::{self, OwnedKVList, Record, Level};
 use std::borrow::Cow;
 use std::ffi::CStr;
 use std::fmt;
@@ -92,6 +92,9 @@ pub struct SyslogConfig {
     /// in garbled output.
     pub log_perror: bool,
 
+    /// Log all messages with the given priority
+    pub log_priority: Option<Level>,
+
     #[serde(skip)]
     __non_exhaustive: (),
 }
@@ -129,6 +132,11 @@ impl SyslogConfig {
             false => b,
         };
 
+        let b = match self.log_priority {
+            Some(priority) => b.log_priority(priority),
+            None => b,
+        };
+
         b
     }
 
@@ -147,6 +155,7 @@ impl Default for SyslogConfig {
             log_pid: false,
             log_delay: None,
             log_perror: false,
+            log_priority: None,
             __non_exhaustive: (),
         }
     }


### PR DESCRIPTION
level_mask to set syslog logmask using setlogmask

log_priority to log all messages with a given syslog priority, to allow easy logging of Info/Debug messages on macOS.
